### PR TITLE
feat: continue playback across devices

### DIFF
--- a/Cassette/App/CassetteApp.swift
+++ b/Cassette/App/CassetteApp.swift
@@ -9,6 +9,7 @@ import OSLog
 import Foundation
 #if os(iOS)
 import BackgroundTasks
+import UIKit
 #endif
 
 @main
@@ -123,7 +124,9 @@ struct CassetteApp: App {
                 // server is known when prepareCurrentTrackForRestoration resolves the URL.
                 await newContainer.serverService.loadPersistedState()
                 Logger.boot.notice("🟡 loadPersistedState() done — activeServer = \(String(describing: newContainer.serverState.activeServer?.baseURL), privacy: .public)")
-                await newContainer.playerService.restoreSession()
+                if !(await newContainer.playerService.restoreFromOtherDevice()) {
+                    await newContainer.playerService.restoreSession()
+                }
                 Task { await runCoverArtGarbageCollection(container: newContainer) }
                 // Cold start fallback: primary trigger for Wrapped updates (BGTask is best-effort).
                 // Fire-and-forget — must never block app launch.
@@ -142,8 +145,20 @@ struct CassetteApp: App {
                 await c.playerService.handleNetworkRestored()
                 await c.listenBrainzService.flushOfflineQueue()
             }
+            #if os(iOS)
+            .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
+                guard let c = container,
+                      c.playerState.playbackState == .paused else { return }
+                Task { _ = await c.playerService.restoreFromOtherDevice() }
+            }
+            #endif
             #if os(macOS)
             .frame(minHeight: 580)
+            .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { _ in
+                guard let c = container,
+                      c.playerState.playbackState == .paused else { return }
+                Task { _ = await c.playerService.restoreFromOtherDevice() }
+            }
             .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
                 guard let c = container else { return }
                 // Stop AVAudioEngine synchronously — prevents HALC frame accumulation during teardown.
@@ -164,6 +179,11 @@ struct CassetteApp: App {
             #endif
         }
         .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .active,
+               let c = container,
+               c.playerState.playbackState == .paused {
+                Task { _ = await c.playerService.restoreFromOtherDevice() }
+            }
             #if os(iOS)
             if newPhase == .inactive, let c = container {
                 Task { await c.playerService.saveCurrentPosition() }

--- a/Cassette/App/CassetteApp.swift
+++ b/Cassette/App/CassetteApp.swift
@@ -178,14 +178,20 @@ struct CassetteApp: App {
             }
             #endif
         }
-        .onChange(of: scenePhase) { _, newPhase in
+        .onChange(of: scenePhase) { oldPhase, newPhase in
             if newPhase == .active,
                let c = container,
                c.playerState.playbackState == .paused {
                 Task { _ = await c.playerService.restoreFromOtherDevice() }
             }
             #if os(iOS)
-            if newPhase == .inactive, let c = container {
+            // `.inactive` occurs in both directions on iOS:
+            //   active -> inactive -> background (leaving)
+            //   background -> inactive -> active (returning)
+            // Only flush while leaving. Flushing during the return path uploads this
+            // device's stale queue immediately before `.active` fetches continuation,
+            // overwriting the newer queue written by the other device.
+            if oldPhase == .active, newPhase == .inactive, let c = container {
                 Task { await c.playerService.saveCurrentPosition() }
                 Logger.session.info("App inactive — position flushed (iOS kill guard)")
             }

--- a/Cassette/Localizable.xcstrings
+++ b/Cassette/Localizable.xcstrings
@@ -7099,6 +7099,58 @@
         }
       }
     },
+    "Continue Across Devices" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geräteübergreifend fortsetzen"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Συνέχεια σε όλες τις συσκευές"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuar entre dispositivos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuer sur plusieurs appareils"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continua su altri dispositivi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デバイス間で再生を続ける"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跨设备继续播放"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跨裝置繼續播放"
+          }
+        }
+      }
+    },
     "Copyright" : {
       "localizations" : {
         "de" : {
@@ -30409,6 +30461,58 @@
         }
       }
     },
+    "When Cassette opens or becomes active while paused, load the queue, song, and position from the same server account. Playback remains paused until you press Play. This setting applies only to this device." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wenn Cassette geöffnet oder im pausierten Zustand wieder aktiv wird, werden Warteschlange, Titel und Wiedergabeposition desselben Serverkontos geladen. Die Wiedergabe bleibt pausiert, bis du auf „Wiedergabe“ drückst. Diese Einstellung gilt nur für dieses Gerät."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Όταν το Cassette ανοίγει ή ενεργοποιείται ενώ η αναπαραγωγή είναι σε παύση, φορτώνει την ουρά, το τραγούδι και τη θέση από τον ίδιο λογαριασμό διακομιστή. Η αναπαραγωγή παραμένει σε παύση μέχρι να πατήσετε Αναπαραγωγή. Αυτή η ρύθμιση ισχύει μόνο για αυτήν τη συσκευή."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cuando Cassette se abre o vuelve a estar activo mientras la reproducción está en pausa, carga la cola, la canción y la posición de la misma cuenta del servidor. La reproducción permanece en pausa hasta que pulses Reproducir. Este ajuste solo se aplica a este dispositivo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lorsque Cassette s’ouvre ou redevient actif alors que la lecture est en pause, l’app charge la file d’attente, le morceau et la position depuis le même compte serveur. La lecture reste en pause jusqu’à ce que vous appuyiez sur Lecture. Ce réglage s’applique uniquement à cet appareil."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quando Cassette viene aperto o torna attivo mentre la riproduzione è in pausa, carica la coda, il brano e la posizione dallo stesso account del server. La riproduzione rimane in pausa finché non premi Riproduci. Questa impostazione si applica solo a questo dispositivo."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cassetteを開いたとき、または一時停止中にアプリが再びアクティブになったとき、同じサーバーアカウントからキュー、曲、再生位置を読み込みます。「再生」を押すまで再生は一時停止のままです。この設定はこのデバイスにのみ適用されます。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当 Cassette 打开或在暂停状态下重新变为活跃时，会从同一服务器账户加载队列、歌曲和播放位置。播放会保持暂停，直到你点按“播放”。此设置仅适用于这台设备。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "當 Cassette 開啟或在暫停狀態下再次變為使用中時，會從相同的伺服器帳號載入佇列、歌曲和播放位置。播放會保持暫停，直到你點按「播放」。此設定僅適用於這部裝置。"
+          }
+        }
+      }
+    },
     "Without it, mood playlists still work, built from your library's genre, BPM and mood tags. The match is rougher." : {
       "localizations" : {
         "de" : {
@@ -31762,5 +31866,5 @@
       }
     }
   },
-  "version" : "1.0"
+  "version" : "1.1"
 }

--- a/Cassette/Models/Persistence/QueueSnapshot.swift
+++ b/Cassette/Models/Persistence/QueueSnapshot.swift
@@ -7,7 +7,6 @@ import Foundation
 import SwiftData
 
 /// Snapshot of the play queue persisted on app background for restoration on next launch.
-/// TODO(v1.x): extend with bidirectional server sync via savePlayQueue / getPlayQueue.
 @Model
 final class QueueSnapshot {
     var id: UUID

--- a/Cassette/Services/Implementations/LibraryService.swift
+++ b/Cassette/Services/Implementations/LibraryService.swift
@@ -129,12 +129,16 @@ actor LibraryService: LibraryServiceProtocol {
     }
 
     func savePlayQueue(songIds: [String], currentIndex: Int, positionSeconds: Double) async throws {
-        // TODO(v1.x): verify Navidrome savePlayQueue support; implement best-effort sync
+        let current = songIds.indices.contains(currentIndex) ? songIds[currentIndex] : nil
+        try await client().savePlayQueue(
+            ids: songIds,
+            current: current,
+            position: max(0, positionSeconds)
+        )
     }
 
     func getPlayQueue() async throws -> SavedPlayQueue? {
-        // TODO(v1.x): implement best-effort queue restore from server
-        return nil
+        try await client().getPlayQueue()
     }
 
     // MARK: - Artist tracks

--- a/Cassette/Services/Implementations/PlayerService.swift
+++ b/Cassette/Services/Implementations/PlayerService.swift
@@ -17,6 +17,31 @@ nonisolated enum CrossfadePhase: Sendable {
     case fadeIn
 }
 
+nonisolated enum PlaybackContinuationPreference {
+    /// Kept device-local on purpose so each installation can opt in independently.
+    static let userDefaultsKey = "cassette.playback.continuationEnabled"
+    private static let deviceIdentifierKey = "cassette.playback.continuationDeviceIdentifier"
+
+    static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: userDefaultsKey) == nil || defaults.bool(forKey: userDefaultsKey)
+    }
+
+    static func deviceIdentifier(defaults: UserDefaults = .standard) -> String {
+        if let saved = defaults.string(forKey: deviceIdentifierKey) { return saved }
+        let identifier = UUID().uuidString
+        defaults.set(identifier, forKey: deviceIdentifierKey)
+        return identifier
+    }
+
+    static func serverClientName(defaults: UserDefaults = .standard) -> String {
+        #if os(macOS)
+        return "Cassette-macOS-\(deviceIdentifier(defaults: defaults))"
+        #else
+        return "Cassette-iOS-\(deviceIdentifier(defaults: defaults))"
+        #endif
+    }
+}
+
 actor PlayerService: PlayerServiceProtocol {
     nonisolated let state: PlayerState
 
@@ -86,6 +111,8 @@ actor PlayerService: PlayerServiceProtocol {
     }
     nonisolated var restoredVolume: Float { Self.persistedVolume() }
     private var positionSaveTask: Task<Void, Never>?
+    private var lastServerQueueSaveAt = Date.distantPast
+    private var isCheckingRemoteContinuation = false
     /// Task reserved for the playing-now notification. Cancelled on track change.
     private var playingNowTask: Task<Void, Never>?
     private var detector = ScrobbleThresholdDetector()
@@ -934,6 +961,7 @@ actor PlayerService: PlayerServiceProtocol {
         await pushPositionSnapshot(rate: 1.0)
         startProgressTimer()
         startPositionSaveTimer()
+        await saveSession()
         let resumeTrack = await MainActor.run { state.currentTrack }
         if let ws = widgetSyncService {
             Task { [weak ws] in await ws?.onPlayStateChanged(isPlaying: true, currentSong: resumeTrack) }
@@ -1027,6 +1055,7 @@ actor PlayerService: PlayerServiceProtocol {
         audioPlayer.seek(to: position)
         await MainActor.run { state.position = position }
         await pushPositionSnapshot()
+        await saveSession()
     }
 
     // MARK: - Skip
@@ -1247,12 +1276,61 @@ actor PlayerService: PlayerServiceProtocol {
 
     // MARK: - Session persistence
 
+    private func continuePlayback(
+        queue: [DisplayableSong],
+        currentIndex: Int,
+        position: TimeInterval,
+        shouldResume: Bool,
+        repeatMode: RepeatMode
+    ) async throws {
+        guard queue.indices.contains(currentIndex) else { return }
+
+        // Tear down any local playback before replacing its queue. `stop()` also cancels pending
+        // restore/crossfade work, which prevents an old delegate callback from racing continuation.
+        await stop()
+        stoppedAtEndOfQueue = false
+
+        let track = queue[currentIndex]
+        let safePosition: TimeInterval
+        if position.isFinite {
+            safePosition = track.duration > 0
+                ? min(max(0, position), max(0, track.duration - 0.25))
+                : max(0, position)
+        } else {
+            safePosition = 0
+        }
+
+        await MainActor.run {
+            state.queue = queue
+            state.currentIndex = currentIndex
+            state.currentTrack = track
+            state.currentRadio = nil
+            state.position = safePosition
+            state.duration = track.duration
+            state.repeatMode = repeatMode
+            state.playbackState = .paused
+        }
+
+        await prepareCurrentTrackForRestoration(track: track, position: safePosition)
+        let isAvailable = await MainActor.run { state.isPlaybackAvailable }
+        guard isAvailable else {
+            throw CassetteError.offlineUnavailable(songId: track.id)
+        }
+
+        await saveSession()
+        if shouldResume {
+            await resume()
+        }
+        Logger.player.info("Playback continued from another device: \(queue.count) tracks, index \(currentIndex), pos=\(safePosition, format: .fixed(precision: 1))s")
+    }
+
     /// Lightweight position-only flush — called from scenePhase .inactive on iOS
     /// to protect the current position against a fast process kill.
     func saveCurrentPosition() async {
         let pos = audioPlayer.progress
         guard pos > 0 else { return }
         await sessionService.savePosition(pos)
+        Task { [weak self] in await self?.saveServerPlayQueueIfNeeded(force: true) }
     }
 
     private func saveSession() async {
@@ -1266,6 +1344,65 @@ actor PlayerService: PlayerServiceProtocol {
             )
         }
         await sessionService.save(playerState: snapshot)
+        Task { [weak self] in await self?.saveServerPlayQueueIfNeeded(force: true) }
+    }
+
+    /// Checks once on launch or eligible app activation and accepts the queue written by another
+    /// Cassette installation using the same authenticated server account.
+    func restoreFromOtherDevice() async -> Bool {
+        guard PlaybackContinuationPreference.isEnabled(), !isCheckingRemoteContinuation else {
+            return false
+        }
+        isCheckingRemoteContinuation = true
+        defer { isCheckingRemoteContinuation = false }
+        do {
+            guard let remote = try await libraryService.getPlayQueue(), !remote.entry.isEmpty else {
+                return false
+            }
+            guard remote.changedBy != PlaybackContinuationPreference.serverClientName() else {
+                return false
+            }
+
+            let queue = remote.entry.map { DisplayableSong(from: $0) }
+            let currentIndex = remote.current.flatMap { current in
+                queue.firstIndex { $0.id == current }
+            } ?? 0
+            let local = await MainActor.run { (state.queue.map(\.id), state.repeatMode) }
+            let repeatMode: RepeatMode = local.0 == queue.map(\.id) ? local.1 : .off
+            try await continuePlayback(
+                queue: queue,
+                currentIndex: currentIndex,
+                position: remote.position ?? 0,
+                shouldResume: false,
+                repeatMode: repeatMode
+            )
+            Logger.player.info("Playback continuation restored \(queue.count, privacy: .public) server tracks")
+            return true
+        } catch {
+            Logger.player.debug("Playback continuation unavailable; keeping local session: \(error, privacy: .public)")
+            return false
+        }
+    }
+
+    private func saveServerPlayQueueIfNeeded(force: Bool) async {
+        guard PlaybackContinuationPreference.isEnabled() else { return }
+        let now = Date()
+        guard force || now.timeIntervalSince(lastServerQueueSaveAt) >= 5 else { return }
+
+        let snapshot = await MainActor.run {
+            (state.queue.map(\.id), state.currentIndex, state.position, state.currentTrack != nil)
+        }
+        guard snapshot.3, !snapshot.0.isEmpty else { return }
+        lastServerQueueSaveAt = now
+        do {
+            try await libraryService.savePlayQueue(
+                songIds: snapshot.0,
+                currentIndex: snapshot.1,
+                positionSeconds: snapshot.2
+            )
+        } catch {
+            Logger.player.debug("Server play-queue save skipped: \(error, privacy: .public)")
+        }
     }
 
     func restoreSession() async {
@@ -1403,6 +1540,7 @@ actor PlayerService: PlayerServiceProtocol {
                 }
                 guard isPlaying else { continue }
                 await sessionService.savePosition(pos)
+                await saveServerPlayQueueIfNeeded(force: false)
             }
         }
     }

--- a/Cassette/Services/Implementations/ServerService.swift
+++ b/Cassette/Services/Implementations/ServerService.swift
@@ -254,7 +254,12 @@ actor ServerService: ServerServiceProtocol {
 
         let transport = CustomHeadersTransport(headers: creds.customHeaders)
         return SwiftSonicClient(
-            configuration: ServerConfiguration(serverURL: url, username: snapshot.username, password: creds.password),
+            configuration: ServerConfiguration(
+                serverURL: url,
+                username: snapshot.username,
+                password: creds.password,
+                clientName: PlaybackContinuationPreference.serverClientName()
+            ),
             transport: transport,
             logSubsystem: "app.cassette.server"
         )

--- a/Cassette/Services/Protocols/LibraryServiceProtocol.swift
+++ b/Cassette/Services/Protocols/LibraryServiceProtocol.swift
@@ -96,7 +96,7 @@ protocol LibraryServiceProtocol: AnyObject, Sendable {
     /// queue) is never returned; a short similar set is topped up from the same library heuristic.
     func endlessExtension(seedTrackId: String, targetSize: Int, excludedIds: Set<String>) async throws -> [DisplayableSong]
 
-    // TODO(v1.x): verify Navidrome savePlayQueue / getPlayQueue support before relying on these
+    /// Best-effort cross-device continuation through the Subsonic 1.12 play-queue endpoints.
     func savePlayQueue(songIds: [String], currentIndex: Int, positionSeconds: Double) async throws
     func getPlayQueue() async throws -> SavedPlayQueue?
 

--- a/Cassette/Services/Protocols/PlayerServiceProtocol.swift
+++ b/Cassette/Services/Protocols/PlayerServiceProtocol.swift
@@ -29,6 +29,8 @@ protocol PlayerServiceProtocol: AnyObject, Sendable {
     func removeFromQueue(at index: Int) async
     func moveInQueue(fromIndex: Int, toIndex: Int) async
     func restoreSession() async
+    /// On launch or eligible focus, restores the queue saved by another Cassette installation.
+    func restoreFromOtherDevice() async -> Bool
     func handleNetworkRestored() async
     /// Starts live stream playback of an Internet Radio Station.
     /// Clears the current queue's playing state but preserves the queue itself.
@@ -61,4 +63,8 @@ protocol PlayerServiceProtocol: AnyObject, Sendable {
     /// Stops the audio engine synchronously without going through the actor.
     /// Only safe to call during app termination (single-threaded, no concurrent access).
     nonisolated func stopAudioEngineSync()
+}
+
+extension PlayerServiceProtocol {
+    func restoreFromOtherDevice() async -> Bool { false }
 }

--- a/Cassette/Views/Settings/Sections/ReplayGainSettingsSection.swift
+++ b/Cassette/Views/Settings/Sections/ReplayGainSettingsSection.swift
@@ -7,11 +7,20 @@ import SwiftUI
 
 struct ReplayGainSettingsSection: View {
     @Environment(\.appContainer) private var container
+    @AppStorage(PlaybackContinuationPreference.userDefaultsKey) private var isPlaybackContinuationEnabled = true
 
     var body: some View {
         let rg = container?.replayGainSettings
 
-        Section("Playback") {
+        Section {
+            Toggle(isOn: $isPlaybackContinuationEnabled) {
+                Label {
+                    Text("Continue Across Devices")
+                } icon: {
+                    SettingsIcon(systemImage: "iphone.and.arrow.forward", color: .blue)
+                }
+            }
+
             Toggle(isOn: Binding(
                 get: { rg?.enabled ?? false },
                 set: { newVal in
@@ -84,6 +93,10 @@ struct ReplayGainSettingsSection: View {
                     }
                 }
             }
+        } header: {
+            Text("Playback")
+        } footer: {
+            Text("When Cassette opens or becomes active while paused, load the queue, song, and position from the same server account. Playback remains paused until you press Play. This setting applies only to this device.")
         }
     }
 


### PR DESCRIPTION
Hello I've implemented a state sync between devices (I saw it was already a TODO).

## Summary

Adds cross-device playback continuation using Subsonic play-queue sync.

| Event | Behavior |
|---|---|
| Playback starts or resumes | Syncs the queue, current song, and position |
| User seeks | Syncs the updated position |
| While playing | Periodically syncs playback progress |
| App moves to the background | Immediately syncs the latest position |
| App launches | Restores state saved by another device |
| App becomes active while paused | Checks for and restores remote state |
| Remote state is restored | Playback remains paused until the user presses Play |

Also a new preference is added in the settings page.

| Setting | Specification |
|---|---|
| **Continue Across Devices** | Located under **Playback** settings |
| Default | Enabled |
| Scope | Stored locally and configured independently per device |
| Disabled | The device neither uploads nor restores cross-device playback state |

LMK if need to change something.