### PR TITLE
feat: add song sharing

### DIFF
--- a/Cassette/DesignSystem/Components/ItemContextMenus.swift
+++ b/Cassette/DesignSystem/Components/ItemContextMenus.swift
@@ -152,6 +152,10 @@ struct SongContextMenuModifier: ViewModifier {
 
             Divider()
 
+            SongShareButton(song: song)
+
+            Divider()
+
             Button {
                 let fav = isFavorite
                 Task {

--- a/Cassette/DesignSystem/Components/SongRow.swift
+++ b/Cassette/DesignSystem/Components/SongRow.swift
@@ -195,6 +195,10 @@ struct SongRow: View {
 
             Divider()
 
+            SongShareButton(song: song)
+
+            Divider()
+
             Button {
                 onAddToPlaylist?(song)
             } label: {

--- a/Cassette/DesignSystem/Components/SongShareButton.swift
+++ b/Cassette/DesignSystem/Components/SongShareButton.swift
@@ -1,0 +1,78 @@
+// Cassette — Music client for Subsonic/OpenSubsonic servers
+// Copyright (C) 2026 Mathieu Dubart
+// Licensed under the Mozilla Public License 2.0.
+// See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+#if os(macOS)
+import AppKit
+#endif
+
+/// The consistent native share action used by player menus and song context menus.
+/// It shares local metadata only and never performs a network request.
+struct SongShareButton: View {
+    let song: DisplayableSong
+    var showsIcon: Bool = true
+
+    var body: some View {
+        #if os(macOS)
+        Button {
+            let text = SongShareContent(song: song).text
+            // Wait for the originating menu to close before showing the sharing-service picker.
+            DispatchQueue.main.async {
+                MacOSSongSharePresenter.present(text: text)
+            }
+        } label: {
+            if showsIcon {
+                Label("Share", systemImage: "square.and.arrow.up")
+            } else {
+                Text("Share")
+            }
+        }
+        #else
+        ShareLink(item: SongShareContent(song: song).text) {
+            Label("Share", systemImage: "square.and.arrow.up")
+        }
+        #endif
+    }
+}
+
+#if os(macOS)
+@MainActor
+private enum MacOSSongSharePresenter {
+    private static var activePicker: NSSharingServicePicker?
+
+    static func present(text: String) {
+        guard let contentView = (NSApp.mainWindow ?? NSApp.keyWindow)?.contentView else { return }
+        let anchor = NSRect(
+            x: contentView.bounds.midX,
+            y: contentView.bounds.maxY - 44,
+            width: 1,
+            height: 1
+        )
+        let picker = NSSharingServicePicker(items: [text])
+        activePicker = picker
+        picker.show(relativeTo: anchor, of: contentView, preferredEdge: .minY)
+    }
+}
+#endif
+
+/// Plain-value share content, kept separate from presentation so formatting is deterministic and testable.
+nonisolated struct SongShareContent: Sendable {
+    let text: String
+
+    init(song: DisplayableSong) {
+        let subtitle = [song.artist, song.albumName]
+            .compactMap { value -> String? in
+                guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      !trimmed.isEmpty else { return nil }
+                return trimmed
+            }
+            .joined(separator: " · ")
+
+        text = subtitle.isEmpty
+            ? "♫ \(song.title)"
+            : "♫ \(song.title)\n\(subtitle)"
+    }
+}

--- a/Cassette/Localizable.xcstrings
+++ b/Cassette/Localizable.xcstrings
@@ -6579,58 +6579,6 @@
         }
       }
     },
-    "Connected — %lld tracks matched a test search." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbunden – %lld Titel entsprachen einer Testsuche."
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Συνδέθηκε — %lld κομμάτια ταίριαξαν σε δοκιμαστική αναζήτηση."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conectado: %lld canciones coincidieron en una búsqueda de prueba."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connecté — %lld morceaux correspondent à une recherche test."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connesso — %lld brani corrispondono a una ricerca di prova."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "接続済み — テスト検索で%lld曲が一致しました。"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已连接 — 测试搜索匹配到 %lld 首曲目。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已連線 — 測試搜尋比對到 %lld 首曲目。"
-          }
-        }
-      }
-    },
     "Connected as" : {
       "localizations" : {
         "de" : {
@@ -6679,6 +6627,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已連線，帳號為"
+          }
+        }
+      }
+    },
+    "Connected — %lld tracks matched a test search." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verbunden – %lld Titel entsprachen einer Testsuche."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Συνδέθηκε — %lld κομμάτια ταίριαξαν σε δοκιμαστική αναζήτηση."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectado: %lld canciones coincidieron en una búsqueda de prueba."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connecté — %lld morceaux correspondent à une recherche test."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connesso — %lld brani corrispondono a una ricerca di prova."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接続済み — テスト検索で%lld曲が一致しました。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已连接 — 测试搜索匹配到 %lld 首曲目。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已連線 — 測試搜尋比對到 %lld 首曲目。"
           }
         }
       }
@@ -23061,7 +23061,7 @@
         }
       }
     },
-    "Share" : {
+     "Share" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -31814,5 +31814,5 @@
       }
     }
   },
-  "version" : "1.1"
+  "version" : "1.0"
 }

--- a/Cassette/Localizable.xcstrings
+++ b/Cassette/Localizable.xcstrings
@@ -6579,58 +6579,6 @@
         }
       }
     },
-    "Connected as" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbunden als"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Συνδεδεμένος ως"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conectado como"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connecté en tant que"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connesso come"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "接続中のアカウント"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已连接为"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已連線，帳號為"
-          }
-        }
-      }
-    },
     "Connected — %lld tracks matched a test search." : {
       "localizations" : {
         "de" : {
@@ -6679,6 +6627,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已連線 — 測試搜尋比對到 %lld 首曲目。"
+          }
+        }
+      }
+    },
+    "Connected as" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verbunden als"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Συνδεδεμένος ως"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectado como"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connecté en tant que"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connesso come"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接続中のアカウント"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已连接为"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已連線，帳號為"
           }
         }
       }
@@ -23061,6 +23061,58 @@
         }
       }
     },
+    "Share" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Teilen"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Κοινοποίηση"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compartir"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Partager"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Condividi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "共有"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分享"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分享"
+          }
+        }
+      }
+    },
     "Share your Wrapped" : {
       "localizations" : {
         "de" : {
@@ -31762,5 +31814,5 @@
       }
     }
   },
-  "version" : "1.0"
+  "version" : "1.1"
 }

--- a/Cassette/Views/Main/FullPlayerView.swift
+++ b/Cassette/Views/Main/FullPlayerView.swift
@@ -842,6 +842,10 @@ private struct TrackInfoSection: View {
                         }
                         .disabled(!isOnline || playerState.currentTrack == nil)
                         Divider()
+                        if let track = playerState.currentTrack {
+                            SongShareButton(song: track)
+                            Divider()
+                        }
                         Button("Instant Mix", systemImage: instantMixSymbol) {
                             guard let track = playerState.currentTrack else { return }
                             startInstantMix(from: .song(id: track.id), using: container, startingWith: track)

--- a/Cassette/Views/Main/QueueView.swift
+++ b/Cassette/Views/Main/QueueView.swift
@@ -304,6 +304,10 @@ private struct QueueRow: View {
 
             Divider()
 
+            SongShareButton(song: song)
+
+            Divider()
+
             Button {
                 showAddToPlaylist = true
             } label: {

--- a/Cassette/Views/Platform/macOS/BottomPlayerBar.swift
+++ b/Cassette/Views/Platform/macOS/BottomPlayerBar.swift
@@ -224,6 +224,10 @@ struct BottomPlayerBar: View {
                 showAddToPlaylist = true
             }
             .disabled(noTrack || container?.serverState.isOnline != true)
+            if let track = currentTrack {
+                Divider()
+                SongShareButton(song: track, showsIcon: false)
+            }
             Divider()
             Button(isFavorite ? "Remove from Favorites" : "Add to Favorites") {
                 Task { await toggleFavorite() }

--- a/Cassette/Views/Platform/macOS/FullPlayerExpandedView.swift
+++ b/Cassette/Views/Platform/macOS/FullPlayerExpandedView.swift
@@ -439,6 +439,10 @@ struct FullPlayerExpandedView: View {
             Divider()
             Button("Add to Playlist…") { showAddToPlaylist = true }
                 .disabled(!isOnline)
+            if let track = currentTrack {
+                Divider()
+                SongShareButton(song: track, showsIcon: false)
+            }
         } label: {
             Image(systemName: "ellipsis")
                 .font(.system(size: 14))


### PR DESCRIPTION
Hello! I've implemented a new option to share songs using the system share sheet.

## Summary

Adds a **Share** action throughout the app, allowing users to share the current song or any song from a list.

| Location | Behavior |
|---|---|
| Song context menu | Shares the selected song |
| Queue | Shares the selected queued song |
| Full player | Shares the currently playing song |
| macOS bottom player | Shares the currently playing song |
| macOS expanded player | Shares the currently playing song |

## Shared Content

The shared text includes the available song metadata.

| Metadata | Format |
|---|---|
| Title | `♫ Song Title` |
| Artist and album | Displayed on a second line, separated by `·` |
| Missing artist or album | Omitted from the shared text |

The feature uses the native system sharing interface on both Apple platforms:

- `ShareLink` on iOS
- `NSSharingServicePicker` on macOS

Sharing only uses locally available metadata and does not perform any additional network requests. The new **Share** action is also localized across the supported languages.

## Screenshots

| macOS | iOS |
|---|---|
| <img width="339" height="258" alt="Share option on macOS" src="https://github.com/user-attachments/assets/031889eb-36cf-4302-a1b2-fd08a144d688" /><br><br><img width="185" height="264" alt="macOS sharing service picker" src="https://github.com/user-attachments/assets/2e5a1b69-6bd9-46d4-a640-7b6cfc9f2d10" /> | <img width="307" height="417" alt="Share option on iOS" src="https://github.com/user-attachments/assets/6d39b276-0ad9-451d-8f46-9b63e515ab2d" /> |

A shared text sample is:

```
♫ The Rumbling (From "Attack on Titan") but it's lofi
Ajotabeats · Ajotabeats & Friends, Vol. 1
```

Let me know if anything needs to be changed!