### PR TITLE
fix: report playback state transitions to OpenSubsonic servers

### DIFF
--- a/Cassette.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Cassette.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MathieuDubart/swiftsonic",
       "state" : {
-        "revision" : "d3e7b5fbee546a39108b48b6ed933dfd4ab41359",
-        "version" : "0.8.2"
+        "revision" : "9ba4b2eb7fcc841a6a6887c96929565b66f8fa90",
+        "version" : "0.9.0"
       }
     },
     {

--- a/Cassette/Services/Implementations/LibraryService.swift
+++ b/Cassette/Services/Implementations/LibraryService.swift
@@ -215,6 +215,38 @@ actor LibraryService: LibraryServiceProtocol {
         }
     }
 
+    func reportPlayback(songId: String, positionMs: Int, state: PlaybackReportState) async {
+        do {
+            let sonicClient = try await client()
+            let capabilities = try await sonicClient.loadCapabilities()
+            guard capabilities.supports(.playbackReport) else {
+                Logger.library.debug("Playback report skipped — server does not advertise the extension")
+                return
+            }
+            try await sonicClient.reportPlayback(
+                mediaId: songId,
+                positionMs: max(0, positionMs),
+                state: Self.swiftSonicPlaybackReportState(for: state),
+                ignoreScrobble: true
+            )
+            Logger.library.debug("Playback report sent for '\(songId, privacy: .public)' state=\(state.rawValue, privacy: .public) positionMs=\(positionMs, privacy: .public)")
+        } catch {
+            // Playback reporting is an optional server extension and must never interrupt audio.
+            Logger.library.debug("Playback report failed for '\(songId, privacy: .public)': \(error, privacy: .public)")
+        }
+    }
+
+    nonisolated static func swiftSonicPlaybackReportState(
+        for state: PlaybackReportState
+    ) -> SwiftSonicClient.PlaybackReportState {
+        switch state {
+        case .starting: return .starting
+        case .playing: return .playing
+        case .paused: return .paused
+        case .stopped: return .stopped
+        }
+    }
+
     func recentlyPlayedAlbums(size: Int) async throws -> [AlbumID3] {
         try await client().getAlbumList2(type: .recent, size: size)
     }

--- a/Cassette/Services/Implementations/PlayerService.swift
+++ b/Cassette/Services/Implementations/PlayerService.swift
@@ -43,6 +43,8 @@ actor PlayerService: PlayerServiceProtocol {
     private nonisolated(unsafe) let audioPlayer: AudioPlayer
     private let audioDelegate: AudioStreamingDelegate
     private var progressTask: Task<Void, Never>?
+    /// Serialises reports so a rapid pause/resume or stop/start transition cannot arrive out of order.
+    private var playbackReportTask: Task<Void, Never>?
     /// Pending seek + optional pause applied once the player first reaches `.playing`.
     /// Used for session restoration and end-of-queue rewind.
     private var pendingRestoreInfo: (seekTime: Double, pause: Bool)?
@@ -380,6 +382,8 @@ actor PlayerService: PlayerServiceProtocol {
             state.playbackState = .playing
             state.isPlaybackAvailable = true
         }
+
+        enqueuePlaybackReport(.playing, track: song, position: 0)
 
         startProgressTimer()
 
@@ -880,7 +884,10 @@ actor PlayerService: PlayerServiceProtocol {
         stopProgressTimer()
         stopPositionSaveTimer()
         await saveSession()
-        let pauseTrack = await MainActor.run { state.currentTrack }
+        let (pauseTrack, pausePosition) = await MainActor.run { (state.currentTrack, state.position) }
+        if let pauseTrack {
+            enqueuePlaybackReport(.paused, track: pauseTrack, position: pausePosition)
+        }
         if let ws = widgetSyncService {
             Task { [weak ws] in await ws?.onPlayStateChanged(isPlaying: false, currentSong: pauseTrack) }
         }
@@ -934,7 +941,10 @@ actor PlayerService: PlayerServiceProtocol {
         await pushPositionSnapshot(rate: 1.0)
         startProgressTimer()
         startPositionSaveTimer()
-        let resumeTrack = await MainActor.run { state.currentTrack }
+        let (resumeTrack, resumePosition) = await MainActor.run { (state.currentTrack, state.position) }
+        if let resumeTrack {
+            enqueuePlaybackReport(.playing, track: resumeTrack, position: resumePosition)
+        }
         if let ws = widgetSyncService {
             Task { [weak ws] in await ws?.onPlayStateChanged(isPlaying: true, currentSong: resumeTrack) }
         }
@@ -976,6 +986,10 @@ actor PlayerService: PlayerServiceProtocol {
         }
         liveStreamStallTask?.cancel()
         liveStreamStallTask = nil
+        let (stoppedTrack, stoppedPosition) = await MainActor.run { (state.currentTrack, state.position) }
+        if let stoppedTrack {
+            enqueuePlaybackReport(.stopped, track: stoppedTrack, position: stoppedPosition)
+        }
         audioPlayer.stop()
         #if os(iOS)
         sessionActivationRetryTask?.cancel()
@@ -1891,6 +1905,9 @@ actor PlayerService: PlayerServiceProtocol {
         await saveSession()
 
         let endTrack = await MainActor.run { state.currentTrack }
+        if let endTrack {
+            enqueuePlaybackReport(.stopped, track: endTrack, position: duration)
+        }
         if let ws = widgetSyncService {
             Task { [weak ws] in await ws?.onPlayStateChanged(isPlaying: false, currentSong: endTrack) }
         }
@@ -2018,6 +2035,27 @@ actor PlayerService: PlayerServiceProtocol {
     }
 
     // MARK: - NowPlaying position push
+
+    /// Enqueues a best-effort server report while preserving local playback responsiveness and event order.
+    private func enqueuePlaybackReport(
+        _ state: PlaybackReportState,
+        track: DisplayableSong,
+        position: TimeInterval
+    ) {
+        let previous = playbackReportTask
+        let positionMs = Self.playbackReportPositionMilliseconds(position)
+        playbackReportTask = Task { [libraryService] in
+            _ = await previous?.result
+            await libraryService.reportPlayback(songId: track.id, positionMs: positionMs, state: state)
+        }
+    }
+
+    nonisolated static func playbackReportPositionMilliseconds(_ position: TimeInterval) -> Int {
+        guard position.isFinite else { return 0 }
+        let milliseconds = max(0, position * 1000)
+        guard milliseconds < Double(Int.max) else { return Int.max }
+        return Int(milliseconds.rounded())
+    }
 
     /// Pushes a position-only snapshot when track metadata hasn't changed (pause/resume/seek).
     private func pushPositionSnapshot(rate: Float? = nil) async {

--- a/Cassette/Services/Implementations/PlayerService.swift
+++ b/Cassette/Services/Implementations/PlayerService.swift
@@ -337,6 +337,7 @@ actor PlayerService: PlayerServiceProtocol {
         stopProgressTimer()
         liveStreamStallTask?.cancel()
         liveStreamStallTask = nil
+        let startingPosition = pendingRestoreInfo?.seekTime ?? 0
         currentSource = source
         pendingRestoreInfo = nil
         // Starting a new track can interrupt a muted parking play (end-of-queue rewind)
@@ -369,6 +370,7 @@ actor PlayerService: PlayerServiceProtocol {
             // it, a cold-launched player (default 1.0) plays the first track loud, ignoring a low slider.
             audioPlayer.volume = restoredVolume
         }
+        enqueuePlaybackReport(.starting, track: song, position: startingPosition)
         audioPlayer.play(url: source.url, headers: source.customHeaders)
         if fadingInAllowed {
             performFadeIn(duration: crossfadeConfig.duration)
@@ -383,7 +385,7 @@ actor PlayerService: PlayerServiceProtocol {
             state.isPlaybackAvailable = true
         }
 
-        enqueuePlaybackReport(.playing, track: song, position: 0)
+        enqueuePlaybackReport(.playing, track: song, position: startingPosition)
 
         startProgressTimer()
 
@@ -894,6 +896,7 @@ actor PlayerService: PlayerServiceProtocol {
     }
 
     func resume() async {
+        let restoredPosition = pendingRestoreInfo?.seekTime
         // User explicitly pressed play — cancel any pending restore auto-pause and lift eof guard.
         restorePauseTask?.cancel()
         restorePauseTask = nil
@@ -943,7 +946,7 @@ actor PlayerService: PlayerServiceProtocol {
         startPositionSaveTimer()
         let (resumeTrack, resumePosition) = await MainActor.run { (state.currentTrack, state.position) }
         if let resumeTrack {
-            enqueuePlaybackReport(.playing, track: resumeTrack, position: resumePosition)
+            enqueuePlaybackReport(.playing, track: resumeTrack, position: restoredPosition ?? resumePosition)
         }
         if let ws = widgetSyncService {
             Task { [weak ws] in await ws?.onPlayStateChanged(isPlaying: true, currentSong: resumeTrack) }
@@ -986,11 +989,11 @@ actor PlayerService: PlayerServiceProtocol {
         }
         liveStreamStallTask?.cancel()
         liveStreamStallTask = nil
+        audioPlayer.stop()
         let (stoppedTrack, stoppedPosition) = await MainActor.run { (state.currentTrack, state.position) }
         if let stoppedTrack {
             enqueuePlaybackReport(.stopped, track: stoppedTrack, position: stoppedPosition)
         }
-        audioPlayer.stop()
         #if os(iOS)
         sessionActivationRetryTask?.cancel()
         sessionActivationRetryTask = nil

--- a/Cassette/Services/Protocols/LibraryServiceProtocol.swift
+++ b/Cassette/Services/Protocols/LibraryServiceProtocol.swift
@@ -6,6 +6,17 @@
 import Foundation
 import SwiftSonic
 
+/// Playback states understood by the OpenSubsonic `reportPlayback` extension.
+///
+/// Kept in the app domain so PlayerService does not depend on the concrete client
+/// implementation. Legacy Subsonic servers simply ignore these reports.
+nonisolated enum PlaybackReportState: String, Sendable, CaseIterable {
+    case starting
+    case playing
+    case paused
+    case stopped
+}
+
 /// A seed for an AudioMuse-AI Instant Mix. The case decides which Subsonic similarity endpoint is used:
 /// song/album seeds go through the folder-based `getSimilarSongs`, an artist seed through the ID3-based
 /// `getSimilarSongs2`. ("Radio" is deliberately avoided — it means Internet radio stations elsewhere.)
@@ -52,6 +63,10 @@ protocol LibraryServiceProtocol: AnyObject, Sendable {
     /// Errors are silenced — scrobble failures must not interrupt playback or surface to the user.
     /// Network/auth errors are logged at debug level.
     func scrobble(songId: String, submission: Bool) async
+
+    /// Reports the current track state and position to servers advertising OpenSubsonic's
+    /// `playbackReport` extension. This is best effort and never interrupts playback.
+    func reportPlayback(songId: String, positionMs: Int, state: PlaybackReportState) async
 
     /// Recently played albums (Subsonic `getAlbumList2?type=recent`).
     /// Granularity is album-level — Subsonic does not expose track-level history endpoints.
@@ -127,6 +142,9 @@ protocol LibraryServiceProtocol: AnyObject, Sendable {
 }
 
 extension LibraryServiceProtocol {
+    /// Default no-op keeps lightweight offline/test conformers source-compatible.
+    func reportPlayback(songId: String, positionMs: Int, state: PlaybackReportState) async {}
+
     /// Default: fall straight through to the library heuristic. `LibraryService` overrides this to
     /// prefer a sonic Instant Mix of the seed track; the default keeps stubs and alternative
     /// conformers working without change.

--- a/CassetteTests/LibraryServiceTests.swift
+++ b/CassetteTests/LibraryServiceTests.swift
@@ -40,3 +40,22 @@ struct LibraryServiceNormalizationTests {
         #expect(LibraryService.normalizeArtistName(normalized) == normalized)
     }
 }
+
+@Suite("Playback report")
+struct PlaybackReportTests {
+
+    @Test("keeps OpenSubsonic playback state names stable")
+    func stateNames() {
+        #expect(PlaybackReportState.allCases.map(\.rawValue) == ["starting", "playing", "paused", "stopped"])
+        #expect(PlaybackReportState.allCases.map { LibraryService.swiftSonicPlaybackReportState(for: $0).rawValue } == PlaybackReportState.allCases.map(\.rawValue))
+    }
+
+    @Test("converts finite playback positions to non-negative milliseconds")
+    func positionMilliseconds() {
+        #expect(PlayerService.playbackReportPositionMilliseconds(263.964) == 263_964)
+        #expect(PlayerService.playbackReportPositionMilliseconds(-1) == 0)
+        #expect(PlayerService.playbackReportPositionMilliseconds(.infinity) == 0)
+        #expect(PlayerService.playbackReportPositionMilliseconds(.nan) == 0)
+        #expect(PlayerService.playbackReportPositionMilliseconds(.greatestFiniteMagnitude) == Int.max)
+    }
+}


### PR DESCRIPTION
## Summary / Problem

Cassette only sent the legacy `scrobble(submission: false)` notification when a track started. When playback was paused, the server kept reporting the track as playing and continued extrapolating its position.

## Changes

- Upgrade the SwiftSonic dependency to `0.9.0`, which provides the OpenSubsonic `reportPlayback` endpoint.
- Detect the server capability before sending optional playback reports and keep unsupported/failed reports best effort.
- Report playing, paused, and stopped transitions with the current position while preserving the existing scrobble behavior.
- Serialize reports so rapid pause/resume and stop/start transitions reach the server in order.
- Add regression coverage for wire-state mapping and position conversion.

## Tests

- `git diff --check` — passed.
- SwiftSonic `0.9.0` dependency API and its endpoint tests were inspected at the pinned release commit.
- `xcodebuild -project Cassette.xcodeproj -scheme Cassette -destination 'generic/platform=iOS' test` — unavailable because this validation host is Windows and has no Xcode/Swift toolchain.

## Compatibility / Known limitations

Servers that do not advertise OpenSubsonic `playbackReport` are skipped without affecting playback. Audio playback and server-side state should also be verified on a real iOS/macOS device with an OpenSubsonic server.

## Issue link

Closes #50
